### PR TITLE
HLSL types

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ Language Server for the Dagor Shader Language. At the moment it's work in progre
 
 ### HLSL
 
-|                      | types        | variables | functions    | keywords | modifiers | semantics | attributes | defines | includes | preprocessor directives |
-| -------------------- | ------------ | --------- | ------------ | -------- | --------- | --------- | ---------- | ------- | -------- | ----------------------- |
-| Code completion      | only builtin | ✓         | only builtin | ✓        | ✓         | ✓         | ✓          | ✓       | ✓        | ✓                       |
-| Go to definition     |              | ✓         |              |          |           |           |            | ✓       | ✓        |                         |
-| Go to declaration    |              | ✓         |              |          |           |           |            | ✓       | ✓        |                         |
-| Go to implementation |              |           |              |          |           |           |            | ✓       | ✓        |                         |
-| Hover                |              | ✓         |              |          |           |           |            | ✓       |          |                         |
-| Document highlights  |              | ✓         |              |          |           |           |            | ✓       |          |                         |
-| Signature help       |              |           |              |          |           |           |            |         |          |                         |
-| Inlay hints          |              |           |              |          |           |           |            | ✓       |          |                         |
-| Document symbols     |              | ✓         |              |          |           |           |            | ✓       |          |                         |
+|                      | types | variables | functions    | keywords | modifiers | semantics | attributes | defines | includes | preprocessor directives |
+| -------------------- | ----- | --------- | ------------ | -------- | --------- | --------- | ---------- | ------- | -------- | ----------------------- |
+| Code completion      | ✓     | ✓         | only builtin | ✓        | ✓         | ✓         | ✓          | ✓       | ✓        | ✓                       |
+| Go to definition     |       | ✓         |              |          |           |           |            | ✓       | ✓        |                         |
+| Go to declaration    |       | ✓         |              |          |           |           |            | ✓       | ✓        |                         |
+| Go to implementation |       |           |              |          |           |           |            | ✓       | ✓        |                         |
+| Hover                |       | ✓         |              |          |           |           |            | ✓       |          |                         |
+| Document highlights  |       | ✓         |              |          |           |           |            | ✓       |          |                         |
+| Signature help       |       |           |              |          |           |           |            |         |          |                         |
+| Inlay hints          |       |           |              |          |           |           |            | ✓       |          |                         |
+| Document symbols     | ✓     | ✓         |              |          |           |           |            | ✓       |          |                         |
 
 ### Features that are part of the repository, but not part of the actual language server
 

--- a/README.md
+++ b/README.md
@@ -12,31 +12,32 @@ Language Server for the Dagor Shader Language. At the moment it's work in progre
 
 ### DSHL
 
-|                      | types | variables | functions | keywords | modifiers | shaders | block statements | macros | includes |
-| -------------------- | ----- | --------- | --------- | -------- | --------- | ------- | ---------------- | ------ | -------- |
-| Code completion      | ✓     | ✓         | ✓         | ✓        | ✓         | ✓       | ✓                | ✓      | ✓        |
-| Go to definition     |       | ✓         |           |          |           | ✓       | ✓                | ✓      | ✓        |
-| Go to declaration    |       | ✓         |           |          |           | ✓       | ✓                | ✓      | ✓        |
-| Go to implementation |       |           |           |          |           | ✓       | ✓                | ✓      | ✓        |
-| Hover                |       | ✓         | ✓         |          |           | ✓       | ✓                | ✓      |          |
-| Document highlights  |       | ✓         | ✓         |          |           | ✓       | ✓                | ✓      |          |
-| Signature help       |       |           | ✓         |          |           |         |                  | ✓      |          |
-| Inlay hints          |       |           | ✓         |          |           |         |                  | ✓      |          |
-| Document symbols     |       | ✓         |           |          |           | ✓       | ✓                | ✓      |          |
+|                      | types | variables | functions | keywords, modifiers | shaders | block statements | macros | includes |
+| -------------------- | ----- | --------- | --------- | ------------------- | ------- | ---------------- | ------ | -------- |
+| Code completion      | ✓     | ✓         | ✓         | ✓                   | ✓       | ✓                | ✓      | ✓        |
+| Go to definition     |       | ✓         |           |                     | ✓       | ✓                | ✓      | ✓        |
+| Go to declaration    |       | ✓         |           |                     | ✓       | ✓                | ✓      | ✓        |
+| Go to implementation |       |           |           |                     | ✓       | ✓                | ✓      | ✓        |
+| Hover                |       | ✓         | ✓         |                     | ✓       | ✓                | ✓      |          |
+| Document highlights  |       | ✓         | ✓         |                     | ✓       | ✓                | ✓      |          |
+| Signature help       |       |           | ✓         |                     |         |                  | ✓      |          |
+| Inlay hints          |       |           | ✓         |                     |         |                  | ✓      |          |
+| Document symbols     |       | ✓         |           |                     | ✓       | ✓                | ✓      |          |
 
 ### HLSL
 
-|                      | types | variables | functions    | keywords | modifiers | semantics | attributes | defines | includes | preprocessor directives |
-| -------------------- | ----- | --------- | ------------ | -------- | --------- | --------- | ---------- | ------- | -------- | ----------------------- |
-| Code completion      | ✓     | ✓         | only builtin | ✓        | ✓         | ✓         | ✓          | ✓       | ✓        | ✓                       |
-| Go to definition     |       | ✓         |              |          |           |           |            | ✓       | ✓        |                         |
-| Go to declaration    |       | ✓         |              |          |           |           |            | ✓       | ✓        |                         |
-| Go to implementation |       |           |              |          |           |           |            | ✓       | ✓        |                         |
-| Hover                |       | ✓         |              |          |           |           |            | ✓       |          |                         |
-| Document highlights  |       | ✓         |              |          |           |           |            | ✓       |          |                         |
-| Signature help       |       |           |              |          |           |           |            |         |          |                         |
-| Inlay hints          |       |           |              |          |           |           |            | ✓       |          |                         |
-| Document symbols     | ✓     | ✓         |              |          |           |           |            | ✓       |          |                         |
+|                       | types | variables | functions    | keywords | modifiers | semantics | attributes | defines | includes | preprocessor directives |
+| --------------------- | ----- | --------- | ------------ | -------- | --------- | --------- | ---------- | ------- | -------- | ----------------------- |
+| Code completion       | ✓     | ✓         | only builtin | ✓        | ✓         | ✓         | ✓          | ✓       | ✓        | ✓                       |
+| Go to definition      | ✓     | ✓         |              |          |           |           |            | ✓       | ✓        |                         |
+| Go to declaration     | ✓     | ✓         |              |          |           |           |            | ✓       | ✓        |                         |
+| Go to implementation  | ✓     |           |              |          |           |           |            | ✓       | ✓        |                         |
+| Go to type definition |       | ✓         |              |          |           |           |            |         |          |                         |
+| Hover                 | ✓     | ✓         |              |          |           |           |            | ✓       |          |                         |
+| Document highlights   | ✓     | ✓         |              |          |           |           |            | ✓       |          |                         |
+| Signature help        |       |           |              |          |           |           |            |         |          |                         |
+| Inlay hints           |       |           |              |          |           |           |            | ✓       |          |                         |
+| Document symbols      | ✓     | ✓         |              |          |           |           |            | ✓       |          |                         |
 
 ### Features that are part of the repository, but not part of the actual language server
 

--- a/grammar/antlr/DshlParser.g4
+++ b/grammar/antlr/DshlParser.g4
@@ -199,7 +199,7 @@ type_declaration:
 
 enum_declaration:
 	ENUM CLASS? (hlsl_identifier (COLON hlsl_identifier)?)? LCB (
-		enum_member ( COMMA enum_member)*
+		enum_member ( COMMA enum_member)* COMMA?
 	)? RCB;
 
 enum_member: hlsl_identifier (ASSIGN expression)?;
@@ -239,6 +239,7 @@ statement:
 	| shader_constant
 	| variable_declaration_statement
 	| type_declaration_statement
+	| enum_declaration_statement
 	| return_statement
 	| break_statement
 	| continue_statement

--- a/src/core/capability-manager.ts
+++ b/src/core/capability-manager.ts
@@ -14,6 +14,7 @@ const capabilities: Capabilities = {
     diagnostics: false,
     diagnosticsVersion: false,
     documentSymbolHierarchy: false,
+    documentSymbolSymbolKinds: [],
     foldingRangeKinds: [],
     hoverFormat: [],
     implementationLink: false,
@@ -38,6 +39,8 @@ export function initializeCapabilities(clientCapabilities: ClientCapabilities): 
     capabilities.diagnosticsVersion = !!clientCapabilities.textDocument?.publishDiagnostics?.versionSupport;
     capabilities.documentSymbolHierarchy =
         !!clientCapabilities.textDocument?.documentSymbol?.hierarchicalDocumentSymbolSupport;
+    capabilities.documentSymbolSymbolKinds =
+        clientCapabilities.textDocument?.documentSymbol?.symbolKind?.valueSet ?? [];
     capabilities.foldingRangeKinds = clientCapabilities.textDocument?.foldingRange?.foldingRangeKind?.valueSet ?? [];
     capabilities.hoverFormat = clientCapabilities.textDocument?.hover?.contentFormat ?? [];
     capabilities.implementationLink = !!clientCapabilities.textDocument?.implementation?.linkSupport;

--- a/src/core/configuration-manager.ts
+++ b/src/core/configuration-manager.ts
@@ -35,7 +35,14 @@ async function refreshConfiguration(initial = false): Promise<void> {
     const newLaunchOptions = await connection.workspace.getConfiguration(LAUNCH_OPTION_CURRENT_CONFIG);
     newConfiguration.launchOptions = {};
     newConfiguration.launchOptions.buildCommand = newLaunchOptions?.Driver?.BuildCommand;
-    newConfiguration.launchOptions.game = newLaunchOptions?.Game;
+    const game = newLaunchOptions?.Game;
+    if (game) {
+        if (typeof game === 'string') {
+            newConfiguration.launchOptions.game = game;
+        } else if (typeof game === 'object') {
+            newConfiguration.launchOptions.game = game.Name;
+        }
+    }
     newConfiguration.launchOptions.platform = newLaunchOptions?.Platform;
     configuration = newConfiguration;
     if (!initial) {

--- a/src/core/document-info.ts
+++ b/src/core/document-info.ts
@@ -191,6 +191,22 @@ export class DocumentInfo {
             offsetPosition(su.originalRange.start, md.contentOriginalRange.start);
             offsetPosition(su.originalRange.end, md.contentOriginalRange.start);
         }
+        for (const td of scope.typeDeclarations) {
+            offsetPosition(td.originalRange.start, md.contentOriginalRange.start);
+            offsetPosition(td.originalRange.end, md.contentOriginalRange.start);
+            offsetPosition(td.nameOriginalRange.start, md.contentOriginalRange.start);
+            offsetPosition(td.nameOriginalRange.end, md.contentOriginalRange.start);
+            for (const m of td.members) {
+                offsetPosition(m.originalRange.start, md.contentOriginalRange.start);
+                offsetPosition(m.originalRange.end, md.contentOriginalRange.start);
+                offsetPosition(m.nameOriginalRange.start, md.contentOriginalRange.start);
+                offsetPosition(m.nameOriginalRange.end, md.contentOriginalRange.start);
+            }
+        }
+        for (const tu of scope.typeUsages) {
+            offsetPosition(tu.originalRange.start, md.contentOriginalRange.start);
+            offsetPosition(tu.originalRange.end, md.contentOriginalRange.start);
+        }
         for (const vd of scope.variableDeclarations) {
             offsetPosition(vd.originalRange.start, md.contentOriginalRange.start);
             offsetPosition(vd.originalRange.end, md.contentOriginalRange.start);

--- a/src/core/document-info.ts
+++ b/src/core/document-info.ts
@@ -155,6 +155,7 @@ export class DocumentInfo {
                         typeDeclarations: [],
                         enumDeclarations: [],
                         typeUsages: [],
+                        enumUsages: [],
                         variableDeclarations: [],
                         variableUsages: [],
                         functionUsages: [],
@@ -221,6 +222,10 @@ export class DocumentInfo {
         for (const tu of scope.typeUsages) {
             offsetPosition(tu.originalRange.start, md.contentOriginalRange.start);
             offsetPosition(tu.originalRange.end, md.contentOriginalRange.start);
+        }
+        for (const eu of scope.enumUsages) {
+            offsetPosition(eu.originalRange.start, md.contentOriginalRange.start);
+            offsetPosition(eu.originalRange.end, md.contentOriginalRange.start);
         }
         for (const vd of scope.variableDeclarations) {
             offsetPosition(vd.originalRange.start, md.contentOriginalRange.start);

--- a/src/core/document-info.ts
+++ b/src/core/document-info.ts
@@ -153,6 +153,7 @@ export class DocumentInfo {
                         shaderDeclarations: [],
                         shaderUsages: [],
                         typeDeclarations: [],
+                        enumDeclarations: [],
                         typeUsages: [],
                         variableDeclarations: [],
                         variableUsages: [],
@@ -197,6 +198,20 @@ export class DocumentInfo {
             offsetPosition(td.nameOriginalRange.start, md.contentOriginalRange.start);
             offsetPosition(td.nameOriginalRange.end, md.contentOriginalRange.start);
             for (const m of td.members) {
+                offsetPosition(m.originalRange.start, md.contentOriginalRange.start);
+                offsetPosition(m.originalRange.end, md.contentOriginalRange.start);
+                offsetPosition(m.nameOriginalRange.start, md.contentOriginalRange.start);
+                offsetPosition(m.nameOriginalRange.end, md.contentOriginalRange.start);
+            }
+        }
+        for (const ed of scope.enumDeclarations) {
+            offsetPosition(ed.originalRange.start, md.contentOriginalRange.start);
+            offsetPosition(ed.originalRange.end, md.contentOriginalRange.start);
+            if (ed.nameOriginalRange) {
+                offsetPosition(ed.nameOriginalRange.start, md.contentOriginalRange.start);
+                offsetPosition(ed.nameOriginalRange.end, md.contentOriginalRange.start);
+            }
+            for (const m of ed.members) {
                 offsetPosition(m.originalRange.start, md.contentOriginalRange.start);
                 offsetPosition(m.originalRange.end, md.contentOriginalRange.start);
                 offsetPosition(m.nameOriginalRange.start, md.contentOriginalRange.start);

--- a/src/core/snapshot.ts
+++ b/src/core/snapshot.ts
@@ -635,6 +635,19 @@ export class Snapshot {
         return null;
     }
 
+    public getTypeDeclarationsInScope(position: Position): TypeDeclaration[] {
+        const result: TypeDeclaration[] = [];
+        let scope: Scope | null = this.getScopeAt(position);
+        while (scope) {
+            result.push(...scope.typeDeclarations.filter((td) => isBeforeOrEqual(td.originalRange.end, position)));
+            for (const hb of scope.hlslBlocks) {
+                result.push(...hb.typeDeclarations.filter((td) => isBeforeOrEqual(td.originalRange.end, position)));
+            }
+            scope = scope.parent ?? null;
+        }
+        return result;
+    }
+
     public getVariableDeclarationsInScope(position: Position, hlsl: boolean): VariableDeclaration[] {
         const result: VariableDeclaration[] = [];
         let scope: Scope | null = this.getScopeAt(position);

--- a/src/core/snapshot.ts
+++ b/src/core/snapshot.ts
@@ -650,6 +650,19 @@ export class Snapshot {
         return result;
     }
 
+    public getEnumDeclarationsInScope(position: Position): EnumDeclaration[] {
+        const result: EnumDeclaration[] = [];
+        let scope: Scope | null = this.getScopeAt(position);
+        while (scope) {
+            result.push(...scope.enumDeclarations.filter((td) => isBeforeOrEqual(td.originalRange.end, position)));
+            for (const hb of scope.hlslBlocks) {
+                result.push(...hb.enumDeclarations.filter((td) => isBeforeOrEqual(td.originalRange.end, position)));
+            }
+            scope = scope.parent ?? null;
+        }
+        return result;
+    }
+
     public getVariableDeclarationsInScope(position: Position, hlsl: boolean): VariableDeclaration[] {
         const result: VariableDeclaration[] = [];
         let scope: Scope | null = this.getScopeAt(position);

--- a/src/core/snapshot.ts
+++ b/src/core/snapshot.ts
@@ -734,9 +734,17 @@ export class Snapshot {
         const result: TypeDeclaration[] = [];
         let scope: Scope | null = this.getScopeAt(position);
         while (scope) {
-            result.push(...scope.typeDeclarations.filter((td) => isBeforeOrEqual(td.originalRange.end, position)));
+            for (const td of scope.typeDeclarations) {
+                if (isBeforeOrEqual(td.originalRange.end, position) && result.every((r) => r.name !== td.name)) {
+                    result.push(td);
+                }
+            }
             for (const hb of scope.hlslBlocks) {
-                result.push(...hb.typeDeclarations.filter((td) => isBeforeOrEqual(td.originalRange.end, position)));
+                for (const td of hb.typeDeclarations) {
+                    if (isBeforeOrEqual(td.originalRange.end, position) && result.every((r) => r.name !== td.name)) {
+                        result.push(td);
+                    }
+                }
             }
             scope = scope.parent ?? null;
         }
@@ -747,9 +755,17 @@ export class Snapshot {
         const result: EnumDeclaration[] = [];
         let scope: Scope | null = this.getScopeAt(position);
         while (scope) {
-            result.push(...scope.enumDeclarations.filter((td) => isBeforeOrEqual(td.originalRange.end, position)));
+            for (const ed of scope.enumDeclarations) {
+                if (isBeforeOrEqual(ed.originalRange.end, position) && result.every((r) => r.name !== ed.name)) {
+                    result.push(ed);
+                }
+            }
             for (const hb of scope.hlslBlocks) {
-                result.push(...hb.enumDeclarations.filter((td) => isBeforeOrEqual(td.originalRange.end, position)));
+                for (const td of hb.enumDeclarations) {
+                    if (isBeforeOrEqual(td.originalRange.end, position) && result.every((r) => r.name !== td.name)) {
+                        result.push(td);
+                    }
+                }
             }
             scope = scope.parent ?? null;
         }
@@ -760,18 +776,28 @@ export class Snapshot {
         const result: VariableDeclaration[] = [];
         let scope: Scope | null = this.getScopeAt(position);
         while (scope) {
-            result.push(
-                ...scope.variableDeclarations.filter(
-                    (vd) => vd.isHlsl === hlsl && isBeforeOrEqual(vd.nameOriginalRange.end, position)
-                )
-            );
+            for (const vd of scope.variableDeclarations) {
+                if (
+                    vd.isHlsl === hlsl &&
+                    !result.some((r) => r.name === vd.name) &&
+                    isBeforeOrEqual(vd.originalRange.end, position)
+                ) {
+                    result.push(vd);
+                }
+            }
             for (const hb of scope.hlslBlocks) {
-                result.push(...hb.variableDeclarations.filter((vd) => isBeforeOrEqual(vd.originalRange.end, position)));
+                for (const vd of hb.variableDeclarations) {
+                    if (isBeforeOrEqual(vd.originalRange.end, position) && result.every((r) => r.name !== vd.name)) {
+                        result.push(vd);
+                    }
+                }
             }
             for (const psb of scope.preshaders) {
-                result.push(
-                    ...psb.variableDeclarations.filter((vd) => isBeforeOrEqual(vd.originalRange.end, position))
-                );
+                for (const vd of psb.variableDeclarations) {
+                    if (isBeforeOrEqual(vd.originalRange.end, position) && result.every((r) => r.name !== vd.name)) {
+                        result.push(vd);
+                    }
+                }
             }
             scope = scope.parent ?? null;
         }
@@ -782,9 +808,11 @@ export class Snapshot {
         const result: ShaderDeclaration[] = [];
         let scope: Scope | null = this.getScopeAt(position);
         while (scope) {
-            result.push(
-                ...scope.shaderDeclarations.filter((vd) => isBeforeOrEqual(vd.nameOriginalRange.end, position))
-            );
+            for (const sd of scope.shaderDeclarations) {
+                if (isBeforeOrEqual(sd.nameOriginalRange.end, position) && result.every((r) => r.name !== sd.name)) {
+                    result.push(sd);
+                }
+            }
             scope = scope.parent ?? null;
         }
         return result;
@@ -797,7 +825,11 @@ export class Snapshot {
             const bds = scope.children
                 .map((s) => s.blockDeclaration)
                 .filter((bd) => bd && isBeforeOrEqual(bd.nameOriginalRange.end, position)) as BlockDeclaration[];
-            result.push(...bds);
+            for (const bd of bds) {
+                if (result.every((r) => r.name !== bd.name)) {
+                    result.push(bd);
+                }
+            }
             scope = scope.parent ?? null;
         }
         return result;

--- a/src/core/snapshot.ts
+++ b/src/core/snapshot.ts
@@ -23,6 +23,7 @@ import { ShaderBlock } from '../interface/shader-block';
 import { ShaderDeclaration } from '../interface/shader/shader-declaration';
 import { ShaderUsage } from '../interface/shader/shader-usage';
 import { SnapshotVersion } from '../interface/snapshot-version';
+import { TypeDeclaration } from '../interface/type/type-declaration';
 import { VariableDeclaration } from '../interface/variable/variable-declaration';
 import { VariableUsage } from '../interface/variable/variable-usage';
 import { getPredefineSnapshot } from '../processor/include-processor';
@@ -691,6 +692,19 @@ export class Snapshot {
         result.push(...scope.variableDeclarations.filter((vd) => vd.isVisible));
         for (const child of scope.children) {
             this.addVariableDeclarations(result, child);
+        }
+    }
+
+    public getAllTypeDeclarations(): TypeDeclaration[] {
+        const result: TypeDeclaration[] = [];
+        this.addTypeDeclarations(result, this.rootScope);
+        return result;
+    }
+
+    private addTypeDeclarations(result: TypeDeclaration[], scope: Scope): void {
+        result.push(...scope.typeDeclarations.filter((vd) => vd.isVisible));
+        for (const child of scope.children) {
+            this.addTypeDeclarations(result, child);
         }
     }
 

--- a/src/core/snapshot.ts
+++ b/src/core/snapshot.ts
@@ -23,6 +23,7 @@ import { ShaderBlock } from '../interface/shader-block';
 import { ShaderDeclaration } from '../interface/shader/shader-declaration';
 import { ShaderUsage } from '../interface/shader/shader-usage';
 import { SnapshotVersion } from '../interface/snapshot-version';
+import { EnumDeclaration } from '../interface/type/enum-declaration';
 import { TypeDeclaration } from '../interface/type/type-declaration';
 import { VariableDeclaration } from '../interface/variable/variable-declaration';
 import { VariableUsage } from '../interface/variable/variable-usage';
@@ -70,6 +71,7 @@ export class Snapshot {
             shaderUsages: [],
             typeDeclarations: [],
             typeUsages: [],
+            enumDeclarations: [],
             variableDeclarations: [],
             variableUsages: [],
             functionDeclarations: [],
@@ -718,6 +720,19 @@ export class Snapshot {
         result.push(...scope.typeDeclarations.filter((vd) => vd.isVisible));
         for (const child of scope.children) {
             this.addTypeDeclarations(result, child);
+        }
+    }
+
+    public getAllEnumDeclarations(): EnumDeclaration[] {
+        const result: EnumDeclaration[] = [];
+        this.addEnumDeclarations(result, this.rootScope);
+        return result;
+    }
+
+    private addEnumDeclarations(result: EnumDeclaration[], scope: Scope): void {
+        result.push(...scope.enumDeclarations.filter((ed) => ed.isVisible));
+        for (const child of scope.children) {
+            this.addEnumDeclarations(result, child);
         }
     }
 

--- a/src/helper/scope.ts
+++ b/src/helper/scope.ts
@@ -7,6 +7,7 @@ import { MacroDeclaration } from '../interface/macro/macro-declaration';
 import { ShaderStage } from '../interface/shader-stage';
 import { ShaderDeclaration } from '../interface/shader/shader-declaration';
 import { ShaderUsage } from '../interface/shader/shader-usage';
+import { EnumDeclaration } from '../interface/type/enum-declaration';
 import { TypeDeclaration } from '../interface/type/type-declaration';
 import { TypeUsage } from '../interface/type/type-usage';
 import { VariableDeclaration } from '../interface/variable/variable-declaration';
@@ -15,6 +16,7 @@ import { VariableUsage } from '../interface/variable/variable-usage';
 export interface Scope {
     shaderDeclarations: ShaderDeclaration[];
     shaderUsages: ShaderUsage[];
+    enumDeclarations: EnumDeclaration[];
     typeDeclarations: TypeDeclaration[];
     typeUsages: TypeUsage[];
     variableDeclarations: VariableDeclaration[];

--- a/src/helper/scope.ts
+++ b/src/helper/scope.ts
@@ -8,6 +8,7 @@ import { ShaderStage } from '../interface/shader-stage';
 import { ShaderDeclaration } from '../interface/shader/shader-declaration';
 import { ShaderUsage } from '../interface/shader/shader-usage';
 import { EnumDeclaration } from '../interface/type/enum-declaration';
+import { EnumUsage } from '../interface/type/enum-usage';
 import { TypeDeclaration } from '../interface/type/type-declaration';
 import { TypeUsage } from '../interface/type/type-usage';
 import { VariableDeclaration } from '../interface/variable/variable-declaration';
@@ -17,6 +18,7 @@ export interface Scope {
     shaderDeclarations: ShaderDeclaration[];
     shaderUsages: ShaderUsage[];
     enumDeclarations: EnumDeclaration[];
+    enumUsages: EnumUsage[];
     typeDeclarations: TypeDeclaration[];
     typeUsages: TypeUsage[];
     variableDeclarations: VariableDeclaration[];

--- a/src/interface/capabilities.ts
+++ b/src/interface/capabilities.ts
@@ -1,4 +1,4 @@
-import { CompletionItemKind, FoldingRangeKind, MarkupKind } from 'vscode-languageserver';
+import { CompletionItemKind, FoldingRangeKind, MarkupKind, SymbolKind } from 'vscode-languageserver';
 
 export interface Capabilities {
     completionDocumentationFormat: MarkupKind[];
@@ -12,6 +12,7 @@ export interface Capabilities {
     diagnostics: boolean;
     diagnosticsVersion: boolean;
     documentSymbolHierarchy: boolean;
+    documentSymbolSymbolKinds: SymbolKind[];
     foldingRangeKinds: FoldingRangeKind[];
     hoverFormat: MarkupKind[];
     implementationLink: boolean;

--- a/src/interface/macro/macro.ts
+++ b/src/interface/macro/macro.ts
@@ -1,5 +1,5 @@
 import { positionsEqual } from '../../helper/helper';
-import { MacroDeclaration } from './macro-declaration';
+import { MacroDeclaration, toStringMacroDeclarationParameterList } from './macro-declaration';
 import { MacroUsage } from './macro-usage';
 
 export interface Macro {
@@ -22,10 +22,10 @@ export function isDeclarationAlreadyAdded(macro: Macro, md: MacroDeclaration): b
     );
 }
 
-export function toStringMacroParameters(m: Macro): string {
+export function toStringMacroParameterList(m: Macro): string {
     const md = m.declarations[0];
     if (!md) {
-        return '';
+        return '()';
     }
-    return md.parameters.map((mp) => mp.name).join(', ');
+    return toStringMacroDeclarationParameterList(md);
 }

--- a/src/interface/macro/macro.ts
+++ b/src/interface/macro/macro.ts
@@ -21,3 +21,11 @@ export function isDeclarationAlreadyAdded(macro: Macro, md: MacroDeclaration): b
         (md2) => md2.uri === md.uri && positionsEqual(md2.originalRange.start, md.originalRange.start)
     );
 }
+
+export function toStringMacroParameters(m: Macro): string {
+    const md = m.declarations[0];
+    if (!md) {
+        return '';
+    }
+    return md.parameters.map((mp) => mp.name).join(', ');
+}

--- a/src/interface/type/enum-declaration.ts
+++ b/src/interface/type/enum-declaration.ts
@@ -1,0 +1,25 @@
+import { DocumentUri, Range } from 'vscode-languageserver';
+import { EnumMemberDeclaration } from './enum-member-declaration';
+
+export interface EnumDeclaration {
+    name?: string;
+    nameOriginalRange?: Range;
+    type?: string;
+    isClass: boolean;
+    originalRange: Range;
+    members: EnumMemberDeclaration[];
+    isVisible: boolean;
+    uri: DocumentUri;
+}
+
+export function toStringEnumDeclaration(ed: EnumDeclaration): string {
+    const keywords = ed.isClass ? 'enum class' : 'enum';
+    const name = ed.name ?? '';
+    const type = ed.type ? `: ${ed.type}` : '';
+    const header = `${keywords} ${name} ${type}`;
+    let members = '';
+    for (const member of ed.members) {
+        members += `\t${member.name},\n`;
+    }
+    return `${header} {\n${members}}`;
+}

--- a/src/interface/type/enum-declaration.ts
+++ b/src/interface/type/enum-declaration.ts
@@ -1,5 +1,6 @@
 import { DocumentUri, Range } from 'vscode-languageserver';
 import { EnumMemberDeclaration } from './enum-member-declaration';
+import { EnumUsage } from './enum-usage';
 
 export interface EnumDeclaration {
     name?: string;
@@ -8,6 +9,7 @@ export interface EnumDeclaration {
     isClass: boolean;
     originalRange: Range;
     members: EnumMemberDeclaration[];
+    usages: EnumUsage[];
     isVisible: boolean;
     uri: DocumentUri;
 }
@@ -21,5 +23,5 @@ export function toStringEnumDeclaration(ed: EnumDeclaration): string {
     for (const member of ed.members) {
         members += `\t${member.name},\n`;
     }
-    return `${header} {\n${members}}`;
+    return `${header} {\n${members}};`;
 }

--- a/src/interface/type/enum-member-declaration.ts
+++ b/src/interface/type/enum-member-declaration.ts
@@ -1,0 +1,7 @@
+import { Range } from 'vscode-languageserver';
+
+export interface EnumMemberDeclaration {
+    name: string;
+    nameOriginalRange: Range;
+    originalRange: Range;
+}

--- a/src/interface/type/enum-usage.ts
+++ b/src/interface/type/enum-usage.ts
@@ -1,0 +1,8 @@
+import { Range } from 'vscode-languageserver';
+import { EnumDeclaration } from './enum-declaration';
+
+export interface EnumUsage {
+    originalRange: Range;
+    declaration: EnumDeclaration;
+    isVisible: boolean;
+}

--- a/src/interface/type/type-declaration.ts
+++ b/src/interface/type/type-declaration.ts
@@ -1,5 +1,5 @@
 import { DocumentUri, Range } from 'vscode-languageserver';
-import { VariableDeclaration } from '../variable/variable-declaration';
+import { VariableDeclaration, toStringVariableDeclaration } from '../variable/variable-declaration';
 import { TypeUsage } from './type-usage';
 
 export interface TypeDeclaration {
@@ -10,4 +10,13 @@ export interface TypeDeclaration {
     members: VariableDeclaration[];
     isVisible: boolean;
     uri: DocumentUri;
+}
+
+export function toStringTypeDeclaration(td: TypeDeclaration): string {
+    const header = `struct ${td.name}`;
+    let members = '';
+    for (const member of td.members) {
+        members += `\t${toStringVariableDeclaration(member)}\n`;
+    }
+    return `${header} {\n${members}}`;
 }

--- a/src/interface/type/type-declaration.ts
+++ b/src/interface/type/type-declaration.ts
@@ -10,6 +10,7 @@ export interface TypeDeclaration {
     members: VariableDeclaration[];
     isVisible: boolean;
     uri: DocumentUri;
+    isBuiltIn: boolean;
 }
 
 export function toStringTypeDeclaration(td: TypeDeclaration): string {
@@ -18,5 +19,5 @@ export function toStringTypeDeclaration(td: TypeDeclaration): string {
     for (const member of td.members) {
         members += `\t${toStringVariableDeclaration(member)}\n`;
     }
-    return `${header} {\n${members}}`;
+    return `${header} {\n${members}};`;
 }

--- a/src/interface/type/type-declaration.ts
+++ b/src/interface/type/type-declaration.ts
@@ -2,7 +2,10 @@ import { DocumentUri, Range } from 'vscode-languageserver';
 import { VariableDeclaration, toStringVariableDeclaration } from '../variable/variable-declaration';
 import { TypeUsage } from './type-usage';
 
+export type TypeKeyword = 'struct' | 'class' | 'interface';
+
 export interface TypeDeclaration {
+    type: TypeKeyword;
     name: string;
     nameOriginalRange: Range;
     originalRange: Range;
@@ -14,7 +17,7 @@ export interface TypeDeclaration {
 }
 
 export function toStringTypeDeclaration(td: TypeDeclaration): string {
-    const header = `struct ${td.name}`;
+    const header = `${td.type} ${td.name}`;
     let members = '';
     for (const member of td.members) {
         members += `\t${toStringVariableDeclaration(member)}\n`;

--- a/src/interface/variable/variable-declaration.ts
+++ b/src/interface/variable/variable-declaration.ts
@@ -1,9 +1,13 @@
 import { DocumentUri, Range } from 'vscode-languageserver';
 import { IntervalDeclaration } from '../interval-declaration';
+import { EnumDeclaration } from '../type/enum-declaration';
+import { TypeDeclaration } from '../type/type-declaration';
 import { VariableUsage } from './variable-usage';
 
 export interface VariableDeclaration {
     type: string;
+    typeDeclaration?: TypeDeclaration;
+    enumDeclaration?: EnumDeclaration;
     name: string;
     nameOriginalRange: Range;
     originalRange: Range;

--- a/src/interface/variable/variable-declaration.ts
+++ b/src/interface/variable/variable-declaration.ts
@@ -19,3 +19,7 @@ export function getVariableTypeWithInterval(vd: VariableDeclaration): string {
     const interval = vd.interval ? 'interval ' : '';
     return interval + vd.type;
 }
+
+export function toStringVariableDeclaration(vd: VariableDeclaration): string {
+    return `${vd.type} ${vd.name};`;
+}

--- a/src/processor/dshl-visitor.ts
+++ b/src/processor/dshl-visitor.ts
@@ -37,7 +37,7 @@ import { ShaderDeclaration } from '../interface/shader/shader-declaration';
 import { ShaderUsage } from '../interface/shader/shader-usage';
 import { EnumDeclaration } from '../interface/type/enum-declaration';
 import { EnumUsage } from '../interface/type/enum-usage';
-import { TypeDeclaration } from '../interface/type/type-declaration';
+import { TypeDeclaration, TypeKeyword } from '../interface/type/type-declaration';
 import { TypeUsage } from '../interface/type/type-usage';
 import { VariableDeclaration } from '../interface/variable/variable-declaration';
 import { VariableUsage } from '../interface/variable/variable-usage';
@@ -511,6 +511,7 @@ export class DshlVisitor extends AbstractParseTreeVisitor<void> implements DshlP
             ? this.snapshot.getOriginalRange(identifier.start.startIndex, identifier.stop!.stopIndex + 1)
             : originalRange;
         const td: TypeDeclaration = {
+            type: this.getType(ctx.type_keyowrd().text),
             name: identifier ? identifier.text : '',
             uri: this.snapshot.getIncludeContextDeepAt(ctx.start.startIndex)?.uri ?? this.snapshot.uri,
             originalRange,
@@ -524,6 +525,14 @@ export class DshlVisitor extends AbstractParseTreeVisitor<void> implements DshlP
         this.type = td;
         this.visitChildren(ctx);
         this.type = null;
+    }
+
+    private getType(type: string): TypeKeyword {
+        if (type === 'struct' || type === 'class' || type === 'interface') {
+            return type;
+        } else {
+            return 'struct';
+        }
     }
 
     public visitEnum_declaration(ctx: Enum_declarationContext): void {

--- a/src/processor/dshl-visitor.ts
+++ b/src/processor/dshl-visitor.ts
@@ -36,7 +36,9 @@ import { shaderStageKeywordToEnum } from '../interface/shader-stage';
 import { ShaderDeclaration } from '../interface/shader/shader-declaration';
 import { ShaderUsage } from '../interface/shader/shader-usage';
 import { EnumDeclaration } from '../interface/type/enum-declaration';
+import { EnumUsage } from '../interface/type/enum-usage';
 import { TypeDeclaration } from '../interface/type/type-declaration';
+import { TypeUsage } from '../interface/type/type-usage';
 import { VariableDeclaration } from '../interface/variable/variable-declaration';
 import { VariableUsage } from '../interface/variable/variable-usage';
 
@@ -514,6 +516,7 @@ export class DshlVisitor extends AbstractParseTreeVisitor<void> implements DshlP
             originalRange,
             nameOriginalRange,
             isVisible: visible,
+            isBuiltIn: false,
             usages: [],
             members: [],
         };
@@ -551,6 +554,7 @@ export class DshlVisitor extends AbstractParseTreeVisitor<void> implements DshlP
                 ),
                 originalRange: this.snapshot.getOriginalRange(em.start.startIndex, em.stop!.stopIndex + 1),
             })),
+            usages: [],
         };
         this.scope.enumDeclarations.push(ed);
         this.visitChildren(ctx);
@@ -573,8 +577,30 @@ export class DshlVisitor extends AbstractParseTreeVisitor<void> implements DshlP
                 identifier.start.startIndex,
                 identifier.stop!.stopIndex + 1
             );
+            const td = this.snapshot.getTypeDeclarationFor(type.text, nameOriginalRange.start);
+            if (td) {
+                const tu: TypeUsage = {
+                    declaration: td,
+                    originalRange: this.snapshot.getOriginalRange(type.start.startIndex, type.stop!.stopIndex + 1),
+                    isVisible: visible,
+                };
+                td.usages.push(tu);
+                this.scope.typeUsages.push(tu);
+            }
+            const ed = this.snapshot.getEnumDeclarationFor(type.text, nameOriginalRange.start);
+            if (ed) {
+                const eu: EnumUsage = {
+                    declaration: ed,
+                    originalRange: this.snapshot.getOriginalRange(type.start.startIndex, type.stop!.stopIndex + 1),
+                    isVisible: visible,
+                };
+                ed.usages.push(eu);
+                this.scope.enumUsages.push(eu);
+            }
             const vd: VariableDeclaration = {
                 type: type.text,
+                typeDeclaration: td ?? undefined,
+                enumDeclaration: ed ?? undefined,
                 name: identifier.text,
                 nameEndPosition: ctx.stop!.stopIndex + 1,
                 originalRange: this.snapshot.getOriginalRange(ctx.start.startIndex, ctx.stop!.stopIndex + 1),
@@ -603,8 +629,30 @@ export class DshlVisitor extends AbstractParseTreeVisitor<void> implements DshlP
                 identifier.start.startIndex,
                 identifier.stop!.stopIndex + 1
             );
+            const td = this.snapshot.getTypeDeclarationFor(type.text, nameOriginalRange.start);
+            if (td) {
+                const tu: TypeUsage = {
+                    declaration: td,
+                    originalRange: this.snapshot.getOriginalRange(type.start.startIndex, type.stop!.stopIndex + 1),
+                    isVisible: visible,
+                };
+                td.usages.push(tu);
+                this.scope.typeUsages.push(tu);
+            }
+            const ed = this.snapshot.getEnumDeclarationFor(type.text, nameOriginalRange.start);
+            if (ed) {
+                const eu: EnumUsage = {
+                    declaration: ed,
+                    originalRange: this.snapshot.getOriginalRange(type.start.startIndex, type.stop!.stopIndex + 1),
+                    isVisible: visible,
+                };
+                ed.usages.push(eu);
+                this.scope.enumUsages.push(eu);
+            }
             const vd: VariableDeclaration = {
                 type: type.text,
+                typeDeclaration: td ?? undefined,
+                enumDeclaration: ed ?? undefined,
                 name: identifier.text,
                 nameEndPosition: ctx.stop!.stopIndex + 1,
                 originalRange: this.snapshot.getOriginalRange(ctx.start.startIndex, ctx.stop!.stopIndex + 1),
@@ -663,6 +711,7 @@ export class DshlVisitor extends AbstractParseTreeVisitor<void> implements DshlP
             typeDeclarations: [],
             typeUsages: [],
             enumDeclarations: [],
+            enumUsages: [],
             variableDeclarations: [],
             variableUsages: [],
             functionDeclarations: [],

--- a/src/provider/completion-provider.ts
+++ b/src/provider/completion-provider.ts
@@ -54,7 +54,7 @@ import { toStringMacroParameterList } from '../interface/macro/macro';
 import { ShaderStage } from '../interface/shader-stage';
 import { dshlSnippets, hlslSnippets } from '../interface/snippets';
 import { EnumDeclaration, toStringEnumDeclaration } from '../interface/type/enum-declaration';
-import { TypeDeclaration, toStringTypeDeclaration } from '../interface/type/type-declaration';
+import { TypeDeclaration, TypeKeyword, toStringTypeDeclaration } from '../interface/type/type-declaration';
 import { getVariableTypeWithInterval } from '../interface/variable/variable-declaration';
 import { getPredefineSnapshot } from '../processor/include-processor';
 import { getIncludeCompletionInfos } from '../processor/include-resolver';
@@ -116,8 +116,8 @@ function addHlslItems(result: CompletionItem[], snapshot: Snapshot, position: Po
     result.push(
         ...tds.map<CompletionItem>((td) => ({
             label: td.name,
-            kind: getKind(CompletionItemKind.Struct),
-            detail: getDetail(td, 'struct'),
+            kind: getTypeCompletionItemKind(td.type),
+            detail: getDetail(td, td.type),
             documentation: getTypeDeclarationDocumentation(td),
         }))
     );
@@ -154,6 +154,16 @@ function addHlslItems(result: CompletionItem[], snapshot: Snapshot, position: Po
     addCompletionItems(result, hlslFunctions, CompletionItemKind.Function, 'function');
     if (getCapabilities().completionSnippets) {
         addCompletionItems(result, hlslSnippets, CompletionItemKind.Snippet, 'snippet');
+    }
+}
+
+function getTypeCompletionItemKind(type: TypeKeyword): CompletionItemKind | undefined {
+    if (type === 'class') {
+        return getKind(CompletionItemKind.Class);
+    } else if (type === 'interface') {
+        return getKind(CompletionItemKind.Interface);
+    } else {
+        return getKind(CompletionItemKind.Struct);
     }
 }
 

--- a/src/provider/declaration-provider.ts
+++ b/src/provider/declaration-provider.ts
@@ -6,5 +6,10 @@ import { linkProviderBase } from './link-provider-base';
 export async function declarationProvider(
     params: DeclarationParams
 ): Promise<Declaration | DeclarationLink[] | undefined | null> {
-    return await linkProviderBase(params.position, params.textDocument.uri, getCapabilities().declarationLink);
+    return await linkProviderBase(
+        params.position,
+        params.textDocument.uri,
+        getCapabilities().declarationLink,
+        'declaration'
+    );
 }

--- a/src/provider/document-symbol-provider.ts
+++ b/src/provider/document-symbol-provider.ts
@@ -20,6 +20,7 @@ import {
     toStringMacroDeclarationHeader,
     toStringMacroDeclarationParameterList,
 } from '../interface/macro/macro-declaration';
+import { TypeKeyword } from '../interface/type/type-declaration';
 import { getVariableTypeWithInterval } from '../interface/variable/variable-declaration';
 
 export async function documentSymbolProvider(
@@ -52,10 +53,10 @@ function addScopedElements(dss: DocumentSymbol[], scope: Scope, uri: DocumentUri
         if (td.isVisible) {
             dss.push({
                 name: td.name,
-                kind: getKind(SymbolKind.Struct),
+                kind: getTypeSymbolKind(td.type),
                 range: td.originalRange,
                 selectionRange: td.nameOriginalRange,
-                detail: 'struct',
+                detail: td.type,
                 children: td.members.map((m) => ({
                     name: m.name,
                     kind: getKind(SymbolKind.Field),
@@ -190,7 +191,7 @@ function createSymbolInformations(snapshot: Snapshot, uri: DocumentUri): SymbolI
     for (const td of tds) {
         result.push({
             name: td.name,
-            kind: getKind(SymbolKind.Struct),
+            kind: getTypeSymbolKind(td.type),
             containerName: td.name,
             location: {
                 range: td.originalRange,
@@ -252,5 +253,15 @@ function getKind(kind: SymbolKind): SymbolKind {
         }
     } else {
         return kinds.includes(kind) ? kind : SymbolKind.File;
+    }
+}
+
+function getTypeSymbolKind(type: TypeKeyword): SymbolKind {
+    if (type === 'class') {
+        return getKind(SymbolKind.Class);
+    } else if (type === 'interface') {
+        return getKind(SymbolKind.Interface);
+    } else {
+        return getKind(SymbolKind.Struct);
     }
 }

--- a/src/provider/document-symbol-provider.ts
+++ b/src/provider/document-symbol-provider.ts
@@ -157,6 +157,18 @@ function createSymbolInformations(snapshot: Snapshot, uri: DocumentUri): SymbolI
     }
     const dss = snapshot.defineStatements.filter((ds) => ds.isVisible);
     addDefines(result, dss, uri);
+    const tds = snapshot.getAllTypeDeclarations();
+    for (const td of tds) {
+        result.push({
+            name: td.name,
+            kind: SymbolKind.Struct,
+            containerName: td.name,
+            location: {
+                range: td.originalRange,
+                uri: td.uri,
+            },
+        });
+    }
     const vds = snapshot.getAllVariableDeclarations();
     for (const vd of vds) {
         result.push({

--- a/src/provider/document-symbol-provider.ts
+++ b/src/provider/document-symbol-provider.ts
@@ -66,6 +66,23 @@ function addScopedElements(dss: DocumentSymbol[], scope: Scope, uri: DocumentUri
             });
         }
     }
+    for (const ed of scope.enumDeclarations) {
+        if (ed.isVisible) {
+            dss.push({
+                name: ed.name ?? '<anonymous>',
+                kind: SymbolKind.Enum,
+                range: ed.originalRange,
+                selectionRange: ed.nameOriginalRange ?? ed.originalRange,
+                detail: 'enum' + (ed.isClass ? ' class' : '') + (ed.type ? ` (${ed.type})` : ''),
+                children: ed.members.map((m) => ({
+                    name: m.name,
+                    kind: SymbolKind.EnumMember,
+                    range: m.originalRange,
+                    selectionRange: m.originalRange,
+                })),
+            });
+        }
+    }
     for (const vd of scope.variableDeclarations) {
         if (vd.isVisible) {
             dss.push({
@@ -157,6 +174,18 @@ function createSymbolInformations(snapshot: Snapshot, uri: DocumentUri): SymbolI
     }
     const dss = snapshot.defineStatements.filter((ds) => ds.isVisible);
     addDefines(result, dss, uri);
+    const eds = snapshot.getAllEnumDeclarations();
+    for (const ed of eds) {
+        result.push({
+            name: ed.name ?? '<anonymous>',
+            kind: SymbolKind.Enum,
+            containerName: ed.name ?? '<anonymous>',
+            location: {
+                range: ed.originalRange,
+                uri: ed.uri,
+            },
+        });
+    }
     const tds = snapshot.getAllTypeDeclarations();
     for (const td of tds) {
         result.push({

--- a/src/provider/hover-provider.ts
+++ b/src/provider/hover-provider.ts
@@ -13,6 +13,8 @@ import { toStringMacroDeclaration } from '../interface/macro/macro-declaration';
 import { MacroUsage, getBestMacroDeclaration } from '../interface/macro/macro-usage';
 import { toStringShaderDeclaration } from '../interface/shader/shader-declaration';
 import { ShaderUsage } from '../interface/shader/shader-usage';
+import { EnumDeclaration, toStringEnumDeclaration } from '../interface/type/enum-declaration';
+import { TypeDeclaration, toStringTypeDeclaration } from '../interface/type/type-declaration';
 import { VariableDeclaration } from '../interface/variable/variable-declaration';
 
 export async function hoverProvider(params: HoverParams): Promise<Hover | undefined | null> {
@@ -34,6 +36,20 @@ export async function hoverProvider(params: HoverParams): Promise<Hover | undefi
         return {
             contents: createDefineHoverContent(dc),
             range: dc.nameOriginalRange,
+        };
+    }
+    const tu = snapshot.getTypeUsageAt(params.position);
+    if (tu) {
+        return {
+            contents: createTypeHoverContent(tu.declaration),
+            range: tu.originalRange,
+        };
+    }
+    const eu = snapshot.getEnumUsageAt(params.position);
+    if (eu) {
+        return {
+            contents: createEnumHoverContent(eu.declaration),
+            range: eu.originalRange,
         };
     }
     const id = snapshot.getIntervalDeclarationAt(params.position);
@@ -121,6 +137,42 @@ function getDefineValue(dc: DefineContext): string {
         } else {
             return `${define}\nExpands to:\n${dc.expansion}`;
         }
+    } else {
+        return '';
+    }
+}
+
+function createTypeHoverContent(td: TypeDeclaration): MarkupContent {
+    return {
+        kind: getCapabilities().hoverFormat.includes(MarkupKind.Markdown) ? MarkupKind.Markdown : MarkupKind.PlainText,
+        value: getTypeValue(td),
+    };
+}
+
+function getTypeValue(td: TypeDeclaration): string {
+    const declaration = toStringTypeDeclaration(td);
+    if (getCapabilities().hoverFormat.includes(MarkupKind.Markdown)) {
+        return `\`\`\`hlsl\n${declaration}\n\`\`\``;
+    } else if (getCapabilities().hoverFormat.includes(MarkupKind.PlainText)) {
+        return declaration;
+    } else {
+        return '';
+    }
+}
+
+function createEnumHoverContent(ed: EnumDeclaration): MarkupContent {
+    return {
+        kind: getCapabilities().hoverFormat.includes(MarkupKind.Markdown) ? MarkupKind.Markdown : MarkupKind.PlainText,
+        value: getEnumValue(ed),
+    };
+}
+
+function getEnumValue(ed: EnumDeclaration): string {
+    const declaration = toStringEnumDeclaration(ed);
+    if (getCapabilities().hoverFormat.includes(MarkupKind.Markdown)) {
+        return `\`\`\`hlsl\n${declaration}\n\`\`\``;
+    } else if (getCapabilities().hoverFormat.includes(MarkupKind.PlainText)) {
+        return declaration;
     } else {
         return '';
     }

--- a/src/provider/implementation-provider.ts
+++ b/src/provider/implementation-provider.ts
@@ -6,5 +6,10 @@ import { linkProviderBase } from './link-provider-base';
 export async function implementationProvider(
     params: ImplementationParams
 ): Promise<Definition | DefinitionLink[] | undefined | null> {
-    return await linkProviderBase(params.position, params.textDocument.uri, getCapabilities().implementationLink, true);
+    return await linkProviderBase(
+        params.position,
+        params.textDocument.uri,
+        getCapabilities().implementationLink,
+        'implementation'
+    );
 }

--- a/src/provider/type-definition-provider.ts
+++ b/src/provider/type-definition-provider.ts
@@ -1,15 +1,15 @@
-import { Definition, DefinitionLink, DefinitionParams } from 'vscode-languageserver';
+import { Definition, DefinitionLink, TypeDefinitionParams } from 'vscode-languageserver';
 
 import { getCapabilities } from '../core/capability-manager';
 import { linkProviderBase } from './link-provider-base';
 
-export async function definitionProvider(
-    params: DefinitionParams
+export async function typeDefinitionProvider(
+    params: TypeDefinitionParams
 ): Promise<Definition | DefinitionLink[] | undefined | null> {
     return await linkProviderBase(
         params.position,
         params.textDocument.uri,
         getCapabilities().definitionLink,
-        'definition'
+        'typeDefinition'
     );
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,7 @@ import { hoverProvider } from './provider/hover-provider';
 import { implementationProvider } from './provider/implementation-provider';
 import { inlayHintProvider } from './provider/inlay-hint-provider';
 import { signatureHelpProvider } from './provider/signature-help-provider';
+import { typeDefinitionProvider } from './provider/type-definition-provider';
 
 export abstract class Server {
     private static server: Server;
@@ -114,6 +115,7 @@ export abstract class Server {
             },
             declarationProvider: true,
             definitionProvider: true,
+            typeDefinitionProvider: true,
             documentHighlightProvider: true,
             documentSymbolProvider: true,
             foldingRangeProvider: true,
@@ -172,6 +174,7 @@ export abstract class Server {
         this.connection.onCompletion(completionProvider);
         this.connection.onDeclaration(declarationProvider);
         this.connection.onDefinition(definitionProvider);
+        this.connection.onTypeDefinition(typeDefinitionProvider);
         this.connection.onDocumentHighlight(documentHighlightProvider);
         this.connection.onDocumentSymbol(documentSymbolProvider);
         this.connection.onFoldingRanges(foldingRangesProvider);


### PR DESCRIPTION
- Adding HLSL structs/classes/interfaces/enums to
  - Document symbols
  - Code completion
  - Hover
  - Document highlights
  - Go to declaration
  - Go to definition
  - Go to implementation

- Adding go to type definition to HLSL variables
- Adding the parameters to macros and defines in code completion
- Updating the game selection logic based on the new vscodeconfig
- Making document symbol kinds more robust
- Preventing duplicated items in code completion